### PR TITLE
Also remove square brackets from single port definitions

### DIFF
--- a/fwsnort
+++ b/fwsnort
@@ -1137,10 +1137,10 @@ sub parse_rule_hdr() {
         }
 
         for my $var (qw(sport dport)) {
+            $hsh{$var} =~ s/\[//;
+            $hsh{$var} =~ s/\]//;
             next unless $hsh{$var} =~ /,/;
             if ($ipt_have_multiport_match) {
-                $hsh{$var} =~ s/\[//;
-                $hsh{$var} =~ s/\]//;
                 my $ctr = 1;
                 my @ports = split /\s*,\s*/, $hsh{$var};
                 my $ports_str = '';
@@ -1162,8 +1162,6 @@ sub parse_rule_hdr() {
                     "$hsh{$var} until the $ipt_str multiport match is supported " .
                     "at line: $line_num.");
                 $hsh{$var} =~ s/,.*//;
-                $hsh{$var} =~ s/\[//;
-                $hsh{$var} =~ s/\]//;
             }
         }
 


### PR DESCRIPTION
Doing the following as root:

```
# fwsnort --update-rules
# fwsnort
# fwsnort --ipt-apply
```

currently results in the following error:

```
[+] Splicing fwsnort 11647 rules into the iptables policy...
iptables-restore v1.6.0: invalid port/service `[6789]' specified
Error occurred at line: 11464
Try `iptables-restore -h' or 'iptables-restore --help' for more information.
```

The issue seems triggered by an updated rule set which seems to be incompatible with Debian's version of fwsnort (1.6.5) as well with the current upstream fwsnort version 1.6.6.

Basically the issue is that all but one line in that rule set contain more than one port. And iptables seems to choke on single port numbers in square brackets.

The offending line:

```
# egrep '\$HOME_NET \[[^],]*\]' /etc/fwsnort/snort_rules/emerging-all.rules
alert tcp $EXTERNAL_NET any -> $HOME_NET [6789] (msg:"ET TROJAN Possible Linux.Mirai DaHua Default Credentials Login"; flow:to_server,established; content:"888888|0d 0a|888888"; depth:14; content:"busybox telnetd -p"; distance:0; reference:url,isc.sans.edu/diary/21833; classtype:attempted-admin; sid:2023674; rev:1;)
```

The resulting line(s) on which iptables-restore bails out:

```
# egrep 'dport \[[^],]*\]' /var/lib/fwsnort/fwsnort.save
-A FWSNORT_FORWARD_ESTAB -p tcp -m tcp --dport [6789] -m string --hex-string "|3838383838380d0a383838383838|" --algo bm --to 78 -m string --hex-string "|62757379626f782074656c6e657464202d70|" --algo bm --from 78 -m comment --comment "sid:2023674; msg:ET TROJAN Possible Linux.Mirai DaHua Default Credentials Login; classtype:attempted-admin; reference:url,isc.sans.edu/diary/21833; rev:1; FWS:1.6.5;" -j LOG --log-ip-options --log-tcp-options --log-prefix "[10620] SID2023674 ESTAB "
-A FWSNORT_INPUT_ESTAB -p tcp -m tcp --dport [6789] -m string --hex-string "|3838383838380d0a383838383838|" --algo bm --to 78 -m string --hex-string "|62757379626f782074656c6e657464202d70|" --algo bm --from 78 -m comment --comment "sid:2023674; msg:ET TROJAN Possible Linux.Mirai DaHua Default Credentials Login; classtype:attempted-admin; reference:url,isc.sans.edu/diary/21833; rev:1; FWS:1.6.5;" -j LOG --log-ip-options --log-tcp-options --log-prefix "[7074] SID2023674 ESTAB "
```
[Initially reported in Debian](https://bugs.debian.org/860164) but [also popped up on Superuser.com](https://superuser.com/questions/1189290/fwsnort-wont-apply-rules-in-iptables/1206722).

This is [the same patch as I used to fix the bug in Debian](https://anonscm.debian.org/cgit/collab-maint/fwsnort.git/tree/debian/patches/fix-dport-bracket-usage.patch) for the upcoming Debian 9 release called _Stretch_.